### PR TITLE
update config/index.js->dev.host

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -13,7 +13,7 @@ module.exports = {
     proxyTable: {},
 
     // Various Dev Server settings
-    host: 'localhost', // can be overwritten by process.env.HOST
+    host: '127.0.0.1', // can be overwritten by process.env.HOST. use 127.0.0.1 or localhost, if use 'localhost' with an error occurred, need to add a line in /etc/hosts is 127.0.0.1 localhost
     port: 9528, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
     autoOpenBrowser: true,
     errorOverlay: true,


### PR DESCRIPTION
建议从localhost修改为127.0.0.1，本机hosts中 如果没有127.0.0.1 localhost则提示错误： getaddrinfo ENOTFOUND localhost。
Proposed changes dev.host from localhost to 127.0.0.1，because native hosts file about 127.0.0.1 localhost there if not exist will give an error: getaddrinfo ENOTFOUND localhost