### PR TITLE
fix: login form width issue in mobile mode

### DIFF
--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -145,6 +145,7 @@ $light_gray:#eee;
     left: 0;
     right: 0;
     width: 520px;
+    max-width: 100%;
     padding: 35px 35px 15px 35px;
     margin: 120px auto;
   }


### PR DESCRIPTION
Before fix:

<img width="285" alt="screen shot 2018-09-06 at 22 35 57" src="https://user-images.githubusercontent.com/5276065/45166394-7ddf7580-b229-11e8-8812-ab941cc8091b.png">

After fix:

<img width="291" alt="screen shot 2018-09-06 at 22 35 31" src="https://user-images.githubusercontent.com/5276065/45166395-7ddf7580-b229-11e8-917e-b89a88aaa521.png">