### PR TITLE
fix[compression]: fix error when enable gzip

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -140,7 +140,6 @@ if (config.build.productionGzip) {
 
   webpackConfig.plugins.push(
     new CompressionWebpackPlugin({
-      asset: '[path].gz[query]',
       algorithm: 'gzip',
       test: new RegExp(
         '\\.(' + config.build.productionGzipExtensions.join('|') + ')$'


### PR DESCRIPTION
Remove deprecated option causing error when building with gzip enable