### PR TITLE
update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "semver": "5.5.0",
     "shelljs": "0.8.2",
     "svg-sprite-loader": "3.8.0",
-    "svgo": "1.0.5",
+    "svgo": "^1.2.1",
     "uglifyjs-webpack-plugin": "1.2.7",
     "url-loader": "1.0.1",
     "vue-loader": "15.3.0",


### PR DESCRIPTION
在执行`npm install`提示：

```bash
$ npm install
npm WARN deprecated bfj-node4@5.3.1: Switch to the `bfj` package for fixes and new features!
npm WARN deprecated circular-json@0.3.3: CircularJSON is in maintenance only, flatted is its successor.

> fsevents@1.2.7 install /Users/baoguoxiao/code/web/vue-admin-template/node_modules/fsevents
> node install

node-pre-gyp WARN Using request for node-pre-gyp https download
[fsevents] Success: "/Users/baoguoxiao/code/web/vue-admin-template/node_modules/fsevents/lib/binding/Release/node-v64-darwin-x64/fse.node" is installed via remote

> node-sass@4.11.0 install /Users/baoguoxiao/code/web/vue-admin-template/node_modules/node-sass
> node scripts/install.js

Cached binary found at /Users/baoguoxiao/.npm/node-sass/4.11.0/darwin-x64-64_binding.node

> node-sass@4.11.0 postinstall /Users/baoguoxiao/code/web/vue-admin-template/node_modules/node-sass
> node scripts/build.js

Binary found at /Users/baoguoxiao/code/web/vue-admin-template/node_modules/node-sass/vendor/darwin-x64-64/binding.node
Testing binary
Binary is fine
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN script-ext-html-webpack-plugin@2.0.1 requires a peer of html-webpack-plugin@^3.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN vue-admin-template@3.9.0 No repository field.

added 1454 packages from 802 contributors and audited 15766 packages in 108.802s
found 2 moderate severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
```
执行`npm audit fix`后发现`svgo`的版本更新了，所以提交pr更新版本