### PR TITLE
Resolve sidebar path with posix format.

### DIFF
--- a/src/layout/components/Sidebar/SidebarItem.vue
+++ b/src/layout/components/Sidebar/SidebarItem.vue
@@ -30,6 +30,7 @@ import { isExternal } from '@/utils/validate'
 import Item from './Item'
 import AppLink from './Link'
 import FixiOSBug from './FixiOSBug'
+const resolve = path.posix ? path.posix.resolve : path.resolve
 
 export default {
   name: 'SidebarItem',
@@ -88,7 +89,7 @@ export default {
       if (isExternal(this.basePath)) {
         return this.basePath
       }
-      return path.resolve(this.basePath, routePath)
+      return resolve(this.basePath, routePath)
     }
   }
 }


### PR DESCRIPTION
原来的写法在electron windows环境下会解析成windows风格的路径导致路由失效，可写成强制解析为posix风格处理这个问题。