### PR TITLE
move the "logout" click event to item

### DIFF
--- a/src/layout/components/Navbar.vue
+++ b/src/layout/components/Navbar.vue
@@ -22,8 +22,8 @@
           <a target="_blank" href="https://panjiachen.github.io/vue-element-admin-site/#/">
             <el-dropdown-item>Docs</el-dropdown-item>
           </a>
-          <el-dropdown-item divided>
-            <span style="display:block;" @click="logout">Log Out</span>
+          <el-dropdown-item divided @click.native="logout">
+            <span style="display:block;">Log Out</span>
           </el-dropdown-item>
         </el-dropdown-menu>
       </el-dropdown>


### PR DESCRIPTION
move the "logout" click event to tag <el-dropdown-item> with @click.native, so that you didn't need to click the span body accurately for logout

将logout的事件监听移到外层的 <el-dropdown-item>标签上，当点击退出按钮不是必须精确的点击“Log Out”字体才能成功，提高用户体验。