### PR TITLE
Increase the webpack configuration to enable Gzip

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
     "chalk": "2.4.2",
+    "compression-webpack-plugin": "^3.0.0",
     "connect": "3.6.6",
     "eslint": "5.15.3",
     "eslint-plugin-vue": "5.2.2",

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,5 +1,4 @@
 module.exports = {
-
   title: 'Vue Admin Template',
 
   /**
@@ -12,5 +11,11 @@ module.exports = {
    * @type {boolean} true | false
    * @description Whether show the logo in sidebar
    */
-  sidebarLogo: false
+  sidebarLogo: false,
+
+  /**
+   * @type {boolean} true | false
+   * @description Whether to enable compression
+   */
+  openGzip: false
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -82,6 +82,7 @@ module.exports = {
   chainWebpack(config) {
     config.plugins.delete('preload') // TODO: need test
     config.plugins.delete('prefetch') // TODO: need test
+
     // set svg-sprite-loader
     config.module
       .rule('svg')
@@ -116,7 +117,9 @@ module.exports = {
         config => config.devtool('cheap-source-map')
       )
 
-    config.when(process.env.NODE_ENV !== 'development', config => {
+    config
+      .when(process.env.NODE_ENV !== 'development',
+        config => {
           config
             .plugin('ScriptExtHtmlWebpackPlugin')
             .after('html')


### PR DESCRIPTION
您的vue-element-admin文档中[分析构建文件体积](https://panjiachen.github.io/vue-element-admin-site/zh/guide/essentials/deploy.html#%E5%88%86%E6%9E%90%E6%9E%84%E5%BB%BA%E6%96%87%E4%BB%B6%E4%BD%93%E7%A7%AF),有提到开启gzip,但是需要开发者自己配置,这个需求几乎上线必备,可以添加到模板中,在文档中说明在**settings.js**中开启即可

另外: vue-element-admin文档 菜单出有个apple,应该是维护者不小心加上去的,麻烦处理一下