### PR TITLE
fix: add route name

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -143,6 +143,7 @@ export const constantRoutes = [
       {
         path: 'menu2',
         component: () => import('@/views/nested/menu2/index'),
+        name: 'Menu2',
         meta: { title: 'menu2' }
       }
     ]


### PR DESCRIPTION
缺少name字段，会导致使用tagsView时候，点击左侧菜单，此项无法添加到tag条。