### PR TITLE
稍微修改了下菜单的显示问题，和路由写法保持一致

### DIFF
--- a/src/layout/components/Sidebar/SidebarItem.vue
+++ b/src/layout/components/Sidebar/SidebarItem.vue
@@ -68,10 +68,7 @@ export default {
         }
       })
 
-      // // When there is only one child router, the child router is displayed by default
-      // if (showingChildren.length === 1) {
-      //   return true
-      // }
+
 
       // Show parent if there are no child router to display
       if (showingChildren.length === 0) {

--- a/src/layout/components/Sidebar/SidebarItem.vue
+++ b/src/layout/components/Sidebar/SidebarItem.vue
@@ -68,10 +68,10 @@ export default {
         }
       })
 
-      // When there is only one child router, the child router is displayed by default
-      if (showingChildren.length === 1) {
-        return true
-      }
+      // // When there is only one child router, the child router is displayed by default
+      // if (showingChildren.length === 1) {
+      //   return true
+      // }
 
       // Show parent if there are no child router to display
       if (showingChildren.length === 0) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -47,6 +47,8 @@ export const constantRoutes = [
     path: '/',
     component: Layout,
     redirect: '/dashboard',
+    name: 'FatherDashboard',
+    meta: {title: 'FatherDashboard', icon: 'dashboard'},
     children: [{
       path: 'dashboard',
       name: 'Dashboard',
@@ -80,6 +82,8 @@ export const constantRoutes = [
   {
     path: '/form',
     component: Layout,
+    name: 'FatherForm',
+    meta: {title: 'FatherForm', icon: 'form'},
     children: [
       {
         path: 'index',
@@ -152,6 +156,8 @@ export const constantRoutes = [
   {
     path: 'external-link',
     component: Layout,
+    name: 'father-external-link',
+    meta: { title: 'F External Link', icon: 'link' },
     children: [
       {
         path: 'https://panjiachen.github.io/vue-element-admin-site/#/',


### PR DESCRIPTION
- 在使用过程中发现当路由只有一个孩子的时候按照框架的逻辑会将这个孩子的属性用<el-menu-item>组件进行显示。

- 但是在大多数情况下如果在路由数组中写法为{path: 'xx', name: 'xx', meta: {title: '父级菜单名'}, children: [{}]}，当只有一个孩子的时候，菜单应显示父级菜单名（<el-submenu>组件）孩子菜单名(el-menu-item组件)

- 当在路由数组中没有children属性的时候，将该路由对象用el-menu-item组件显示即可

-这样就能比较好的将路由对象和菜单显示对应起来，使其保持一致 

