### PR TITLE
fix: 打包后./dist/index.html文件中双引号缺失问题

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -117,13 +117,13 @@ module.exports = {
             })
           // https:// webpack.js.org/configuration/optimization/#optimizationruntimechunk
           config.optimization.runtimeChunk('single')
+
+          config.plugin('html')
+            .tap(args => {
+              args[0].minify.removeAttributeQuotes = false
+              return args
+            })
         }
       )
-    
-    config.plugin('html')
-      .tap(args => {
-        args[0].minify.removeAttributeQuotes = false
-        return args
-      })
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -119,5 +119,11 @@ module.exports = {
           config.optimization.runtimeChunk('single')
         }
       )
+    
+    config.plugin('html')
+      .tap(args => {
+        args[0].minify.removeAttributeQuotes = false
+        return args
+      })
   }
 }


### PR DESCRIPTION
1、修复打包后dist文件夹中index.html文件里面的资源引入时，双引号缺失的问题。
修改前：
<img width="1396" alt="image" src="https://user-images.githubusercontent.com/34416398/155658878-bdee0e9b-1876-4a11-bd68-5fa94e42c543.png">

修改后：
<img width="1475" alt="image" src="https://user-images.githubusercontent.com/34416398/155658967-d68581ba-ca26-414e-bbdf-e82d5d3594f8.png">

