### PR TITLE
fix: npm install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "sass-loader": "8.0.2",
     "script-ext-html-webpack-plugin": "2.1.3",
     "serve-static": "1.13.2",
-    "svg-sprite-loader": "4.1.3",
+    "svg-sprite-loader": "^6.0.11",
     "svgo": "1.2.2",
     "vue-template-compiler": "2.6.10"
   },


### PR DESCRIPTION
解决：issues里面众多的安装依赖失败问题和npm run dev报错问题

1. 安装依赖失败问题 npm yarn 均会失败，建议使用pnpm
2. npm run dev报错，只需要升级一下svg-sprite-loader版本即可
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/73089592/201349986-72a79cc8-cd76-413e-a4d3-9020104bedfa.png">

成功启动！！！