### PR TITLE
修改element-ui版本至2.15.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "axios": "0.18.1",
     "core-js": "3.6.5",
-    "element-ui": "2.13.2",
+    "element-ui": "2.15.6",
     "js-cookie": "2.2.0",
     "normalize.css": "7.0.0",
     "nprogress": "0.2.0",


### PR DESCRIPTION
2.13.2版本el-empty组件无效，2.15.6版本可兼容本项目所有elment-ui组件及el-empty组件。